### PR TITLE
chore: open docs site in same tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -37,7 +37,7 @@
         </svg>
       </button>
     </div>
-    <a href="https://docs.adbc-drivers.org/" class="docs-link" aria-label="Documentation" target="_blank" rel="noopener noreferrer">
+    <a href="https://docs.adbc-drivers.org/" class="docs-link" aria-label="Documentation">
       <span>Docs</span>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" fill="currentColor">
         <path d="M188.58,289.27c-13.35,0-13.35,20.74,0,20.74h159.53c13.38,0,13.38-20.74,0-20.74-53.18,0-106.35,0-159.53,0Z"/>


### PR DESCRIPTION
Removes the `target="_blank"` from the link to the driver docs.